### PR TITLE
Bugs in xGenT execution

### DIFF
--- a/R/functions.r
+++ b/R/functions.r
@@ -23,16 +23,16 @@
 #' gent(z,LD)
 gent=function(zs=NULL,LD,A=NULL,xqtl_Z=NULL,chisquares=NULL) {
     # find null distribution
-    if(is.null(A)) {
+    if(is.null(A) & is.null(xqtl_Z)) {
       mu=nrow(LD)
       trASAS=tr(LD%*%LD)
-    } else if(!is.null(A) & is.null(eqtl_Z)){
+    } else if(!is.null(A) & is.null(xqtl_Z)){
       A=as.matrix(A)
       mu=sum(diag(A%*%LD))
       trASAS=tr(A%*%LD%*%A%*%LD)
-    } else if(is.null(A) & !is.null(eqtl_Z)) {
-      eqtl_Z=as.matrix(eqtl_Z);m=nrow(eqtl_Z);p=ncol(eqtl_Z)
-      L=matrix(0,m,m);for(o in 1:p) L=L+eqtl_Z[,o]%*%t(eqtl_Z[,o])
+    } else if(is.null(A) & !is.null(xqtl_Z)) {
+      xqtl_Z=as.matrix(xqtl_Z);m=nrow(xqtl_Z);p=ncol(xqtl_Z)
+      L=matrix(0,m,m);for(o in 1:p) L=L+xqtl_Z[,o]%*%t(xqtl_Z[,o])
       L=L/sqrt(m*p)
       mu=sum(diag(L%*%LD))
       trASAS=tr(L%*%LD%*%L%*%LD)


### PR DESCRIPTION
There were two bugs in the xGenT function. 

(1) The function accepted xqtl_Z but tried to evaluate eqtl_Z.

(2) It was not possible to run xGenT with the if-else structure. If is.null(A) and !is.null(xqtl_z), then the GenT results were returned because the first if(is.null(A)) conditional was TRUE, precluding the "else if"s. This can be seen by gent(ad_z,LD,xqtl_Z = eqtl_Z) and gent(ad_z,LD) returning the same results.